### PR TITLE
Fix motor config refs

### DIFF
--- a/Slush/Motor.py
+++ b/Slush/Motor.py
@@ -49,7 +49,7 @@ class Motor(sBoard):
             self.setOverCurrent(2000)
             self.setMicroSteps(16)
             self.setCurrent(70, 90, 100, 100)
-            self.setParam([0x1A, 16], 0x3608)
+            self.setParam([0x18, 16], 0x3608)
         if self.boardInUse == 1:
             self.setParam([0x1A, 16], 0x3608)
             self.setCurrent(100, 120, 140, 140)
@@ -246,7 +246,7 @@ class Motor(sBoard):
     def resetDev(self):
         self.xfer(LReg.RESET_DEVICE)
         if self.boardInUse == 1: self.setParam([0x1A, 16], 0x3608)
-        if self.boardInUse == 0: self.setParam([0x1A, 16], 0x3608)
+        if self.boardInUse == 0: self.setParam([0x18, 16], 0x3608)
 
     ''' stop the motor using the decel '''
     def softStop(self):

--- a/Slush/Motor.py
+++ b/Slush/Motor.py
@@ -190,8 +190,8 @@ class Motor(sBoard):
 
     ''' sets the hardstop option for the limit switch '''
     def setLimitHardStop(self, stop):
-        if stop == 1: self.setParam([0x1A, 16], 0x3608)
-        if stop == 0: self.setParam([0x1A, 16], 0x3618)
+        if stop == 1: self.setParam([0x18, 16], 0x3608)
+        if stop == 0: self.setParam([0x18, 16], 0x3618)
 
     ''' go until switch press event occurs '''
     def goUntilPress(self, act, dir, spd):

--- a/Slush/Motor.py
+++ b/Slush/Motor.py
@@ -190,8 +190,12 @@ class Motor(sBoard):
 
     ''' sets the hardstop option for the limit switch '''
     def setLimitHardStop(self, stop):
-        if stop == 1: self.setParam([0x18, 16], 0x3608)
-        if stop == 0: self.setParam([0x18, 16], 0x3618)
+        if self.boardInUse is 0:
+            if stop == 1: self.setParam([0x18, 16], 0x3608)
+            if stop == 0: self.setParam([0x18, 16], 0x3618)
+        if self.boardInUse is 1:
+            if stop == 1: self.setParam([0x1A, 16], 0x3608)
+            if stop == 0: self.setParam([0x1A, 16], 0x3618)
 
     ''' go until switch press event occurs '''
     def goUntilPress(self, act, dir, spd):


### PR DESCRIPTION
Fixes a couple references to the CONFIG register in the Motor.py file. There were inconsistencies due to the L6470 having its config address at 0x18 and the L6480 (high current chips for D) having its address at 0x1A. This also fixes the setLimitHardStop function (For both the XLT and D models).