### PR TITLE
Slush/Cypress conflict fix

### DIFF
--- a/Slush/Board.py
+++ b/Slush/Board.py
@@ -9,8 +9,8 @@ class sBoard:
     """ initalize all of the controllers peripheral devices
     """
     self.initSPI()
+    self.initI2C()
     self.initGPIOState()
-    self.initI2C()    
 	       
   def initGPIOState(self):
     """sets the default states for the GPIO on the slush modules. *This
@@ -74,6 +74,7 @@ class sBoard:
             self.chip.reset()
     except:
         pass
+    print(self.bus.read_byte_data(0x32, 0x05))
 
   def deinitBoard(self):
     """ closes the board and deinits the peripherals

--- a/Slush/Board.py
+++ b/Slush/Board.py
@@ -86,7 +86,6 @@ class sBoard:
             self.chip.reset()
     except:
         pass
-    self.bus.write_byte_data(0x20, 0x05, 0x01)
 
   def deinitBoard(self):
     """ closes the board and deinits the peripherals

--- a/Slush/Board.py
+++ b/Slush/Board.py
@@ -33,6 +33,11 @@ class sBoard:
         gpio.output(SLX.MTR1_ChipSelect, gpio.HIGH)
         gpio.output(SLX.MTR2_ChipSelect, gpio.HIGH)
         gpio.output(SLX.MTR3_ChipSelect, gpio.HIGH)
+
+        # IO expander reset pin
+        gpio.setup(SLX.MCP23_Reset, gpio.OUT)
+        gpio.output(SLX.MCP23_Reset, gpio.HIGH)
+
     elif self.board is 'D':
         gpio.setup(SLX.MTR0_ChipSelect, gpio.OUT)
         gpio.setup(SLX.MTR1_ChipSelect, gpio.OUT)
@@ -50,9 +55,6 @@ class sBoard:
         gpio.output(SLX.MTR6_ChipSelect, gpio.HIGH)
     else:
         raise Exception('Board should be ''XLT'' or ''D''')
-    #IO expander reset pin
-    gpio.setup(SLX.MCP23_Reset, gpio.OUT)
-    gpio.output(SLX.MCP23_Reset, gpio.HIGH)
 
     #preforma a hard reset
     gpio.output(SLX.L6470_Reset, gpio.LOW)

--- a/Slush/Board.py
+++ b/Slush/Board.py
@@ -74,7 +74,7 @@ class sBoard:
             self.chip.reset()
     except:
         pass
-    print(self.bus.read_byte_data(0x32, 0x05))
+    self.bus.write_byte_data(0x20, 0x05, 0x01)
 
   def deinitBoard(self):
     """ closes the board and deinits the peripherals

--- a/Slush/Board.py
+++ b/Slush/Board.py
@@ -5,12 +5,13 @@ class sBoard:
   chip = 0
   bus = 0
 
-  def __init__(self):
+  def __init__(self, board = 'XLT'):
     """ initalize all of the controllers peripheral devices
     """
+    self.board = board
     self.initSPI()
-    self.initI2C()
     self.initGPIOState()
+    self.initI2C()
 	       
   def initGPIOState(self):
     """sets the default states for the GPIO on the slush modules. *This
@@ -23,21 +24,32 @@ class sBoard:
     gpio.setup(SLX.L6470_Reset, gpio.OUT)
     
     #chip select pins, must all be low or SPI will com fail
-    gpio.setup(SLX.MTR0_ChipSelect, gpio.OUT)
-    gpio.setup(SLX.MTR1_ChipSelect, gpio.OUT)
-    gpio.setup(SLX.MTR2_ChipSelect, gpio.OUT)
-    gpio.setup(SLX.MTR3_ChipSelect, gpio.OUT)
-    gpio.setup(SLX.MTR4_ChipSelect, gpio.OUT)
-    gpio.setup(SLX.MTR5_ChipSelect, gpio.OUT)
-    gpio.setup(SLX.MTR6_ChipSelect, gpio.OUT)
-    gpio.output(SLX.MTR0_ChipSelect, gpio.HIGH)
-    gpio.output(SLX.MTR1_ChipSelect, gpio.HIGH)
-    gpio.output(SLX.MTR2_ChipSelect, gpio.HIGH)
-    gpio.output(SLX.MTR3_ChipSelect, gpio.HIGH)
-    gpio.output(SLX.MTR4_ChipSelect, gpio.HIGH)
-    gpio.output(SLX.MTR5_ChipSelect, gpio.HIGH)
-    gpio.output(SLX.MTR6_ChipSelect, gpio.HIGH)
-
+    if self.board is 'XLT':
+        gpio.setup(SLX.MTR0_ChipSelect, gpio.OUT)
+        gpio.setup(SLX.MTR1_ChipSelect, gpio.OUT)
+        gpio.setup(SLX.MTR2_ChipSelect, gpio.OUT)
+        gpio.setup(SLX.MTR3_ChipSelect, gpio.OUT)
+        gpio.output(SLX.MTR0_ChipSelect, gpio.HIGH)
+        gpio.output(SLX.MTR1_ChipSelect, gpio.HIGH)
+        gpio.output(SLX.MTR2_ChipSelect, gpio.HIGH)
+        gpio.output(SLX.MTR3_ChipSelect, gpio.HIGH)
+    elif self.board is 'D':
+        gpio.setup(SLX.MTR0_ChipSelect, gpio.OUT)
+        gpio.setup(SLX.MTR1_ChipSelect, gpio.OUT)
+        gpio.setup(SLX.MTR2_ChipSelect, gpio.OUT)
+        gpio.setup(SLX.MTR3_ChipSelect, gpio.OUT)
+        gpio.setup(SLX.MTR4_ChipSelect, gpio.OUT)
+        gpio.setup(SLX.MTR5_ChipSelect, gpio.OUT)
+        gpio.setup(SLX.MTR6_ChipSelect, gpio.OUT)
+        gpio.output(SLX.MTR0_ChipSelect, gpio.HIGH)
+        gpio.output(SLX.MTR1_ChipSelect, gpio.HIGH)
+        gpio.output(SLX.MTR2_ChipSelect, gpio.HIGH)
+        gpio.output(SLX.MTR3_ChipSelect, gpio.HIGH)
+        gpio.output(SLX.MTR4_ChipSelect, gpio.HIGH)
+        gpio.output(SLX.MTR5_ChipSelect, gpio.HIGH)
+        gpio.output(SLX.MTR6_ChipSelect, gpio.HIGH)
+    else:
+        raise Exception('Board should be ''XLT'' or ''D''')
     #IO expander reset pin
     gpio.setup(SLX.MCP23_Reset, gpio.OUT)
     gpio.output(SLX.MCP23_Reset, gpio.HIGH)


### PR DESCRIPTION
Fixes issue with cypress safe shutdown and initializing Slush.sBoard() conflicting causing a shutdown on initialization. Chip select 5 was on the same pin. This Merger allows the slush board to be specified in the constructor as 'XLT' which will not conflict. And 'D' which will still conflict but it is not in use with RPIMiB. 'XLT' is default